### PR TITLE
Support Swift Package Manager so it can be imported via Xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "SFBDiffableDataSource",
+    platforms: [
+        .macOS(.v10_15),
+    ],
+    products: [
+        .library(name: "SFBDiffableDataSource", targets: ["SFBDiffableDataSource"]),
+    ],
+    targets: [
+        .target(
+            name: "SFBDiffableDataSource",
+            path: "SFBDiffableDataSource")
+    ]
+)

--- a/SFBDiffableDataSource/CollectionViewDiffableDataSource.swift
+++ b/SFBDiffableDataSource/CollectionViewDiffableDataSource.swift
@@ -10,7 +10,7 @@ public class CollectionViewDiffableDataSource<SectionIdentifierType, ItemIdentif
 	public typealias ItemProvider = (NSCollectionView, IndexPath, SectionIdentifierType, ItemIdentifierType) -> NSCollectionViewItem?
 	public typealias SupplementaryViewProvider = (NSCollectionView, NSCollectionView.SupplementaryElementKind, IndexPath, SectionIdentifierType) -> (NSView & NSCollectionViewElement)?
 
-	var supplementaryViewProvider: SupplementaryViewProvider?
+	public var supplementaryViewProvider: SupplementaryViewProvider?
 
 	private weak var collectionView: NSCollectionView?
 	private let itemProvider: ItemProvider


### PR DESCRIPTION
Thanks for this Stephen. It's a shame you had to write so much code to work around a bug in macOS, but it's greatly appreciated.

Since I wanted to try this in my Mac app, I added support for SPM. Feel free to ignore this PR, it's just here if you want it.

* Add Package.swift
* Also make `supplementaryViewProvider` property public so it can be used by client code